### PR TITLE
automate AWS bootstrap with terraform

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -6,10 +6,12 @@
 
 ## GitHub Organization
 
-- [ ] [Set base permissions for the organization](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/setting-base-permissions-for-an-organization) to `Read` or `None` not to make all organization members de-facto admins through GitHub Management
-- [ ] If you plan to keep the GitHub Management repository private, [allow forking of private repositories](https://docs.github.com/en/organizations/managing-organization-settings/managing-the-forking-policy-for-your-organization) and [enable workflows for private repository forks](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#enabling-workflows-for-private-repository-forks)
+- [ ] [Set base permissions for the organization](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/setting-base-permissions-for-an-organization) to `Read` or `None` not to make all organization members de-facto admins through GitHub Management - `gh -X PATCH /orgs/$GITHUB_ORGANIZATION -f default_repository_permission=read`
+- [ ] If you plan to keep the GitHub Management repository private, [allow forking of private repositories](https://docs.github.com/en/organizations/managing-organization-settings/managing-the-forking-policy-for-your-organization) and [enable workflows for private repository forks](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#enabling-workflows-for-private-repository-forks) - `gh -X PATCH /orgs/$GITHUB_ORGANIZATION -f members_can_fork_private_repositories=true` (enabling workflows for private repository forks is not possible through API)
 
 ## AWS
+
+*NOTE*: Setting up AWS can be automated with [terraform](../terraform/bootstrap/aws.tf). If you choose to create AWS with terraform, remember that you'll still need to retrieve `AWS_ACCESS_KEY_ID`s and `AWS_SECRET_ACCESS_KEY`s manually.
 
 - [ ] [Create a S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html) - *this is where Terraform states for the organizations will be stored*
 - [ ] [Create a DynamoDB table](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/getting-started-step-1.html) using `LockID` of type `String` as the partition key - *this is where Terraform state locks will be stored*

--- a/terraform/bootstrap/aws.tf
+++ b/terraform/bootstrap/aws.tf
@@ -1,0 +1,135 @@
+# terraform init
+# export AWS_ACCESS_KEY_ID=
+# export AWS_SECRET_ACCESS_KEY=
+# export AWS_REGION=
+# export TF_VAR_name=
+# terraform apply
+
+terraform {
+  required_providers {
+    aws = {
+      version = "4.5.0"
+    }
+  }
+
+  required_version = "~> 1.1.4"
+}
+
+provider "aws" {}
+
+variable "name" {
+  description = "The name to use for S3 bucket, DynamoDB table and IAM users."
+  type        = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.name
+
+  tags = {
+    Name = "GitHub Management"
+    Url  = "https://github.com/protocol/github-mgmt-template"
+  }
+}
+
+resource "aws_s3_bucket_acl" "this" {
+  bucket = aws_s3_bucket.this.id
+  acl    = "private"
+}
+
+resource "aws_dynamodb_table" "this" {
+  name         = var.name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = {
+    Name = "GitHub Management"
+    Url  = "https://github.com/protocol/github-mgmt-template"
+  }
+}
+
+resource "aws_iam_user" "ro" {
+  name = "${var.name}-ro"
+
+  tags = {
+    Name = "GitHub Management"
+    Url  = "https://github.com/protocol/github-mgmt-template"
+  }
+}
+
+resource "aws_iam_user" "rw" {
+  name = "${var.name}-rw"
+
+  tags = {
+    Name = "GitHub Management"
+    Url  = "https://github.com/protocol/github-mgmt-template"
+  }
+}
+
+data "aws_iam_policy_document" "ro" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["${aws_s3_bucket.this.arn}"]
+    effect    = "Allow"
+  }
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+    effect    = "Allow"
+  }
+
+  statement {
+    actions   = ["dynamodb:GetItem"]
+    resources = ["${aws_dynamodb_table.this.arn}"]
+    effect    = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "rw" {
+  statement {
+    actions   = ["s3:ListBucket"]
+    resources = ["${aws_s3_bucket.this.arn}"]
+    effect    = "Allow"
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+    effect    = "Allow"
+  }
+
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+
+    resources = ["${aws_dynamodb_table.this.arn}"]
+    effect    = "Allow"
+  }
+}
+
+resource "aws_iam_user_policy" "ro" {
+  name = "${var.name}-ro"
+  user = "${aws_iam_user.ro.name}"
+
+  policy = "${data.aws_iam_policy_document.ro.json}"
+}
+
+resource "aws_iam_user_policy" "rw" {
+  name = "${var.name}-rw"
+  user = "${aws_iam_user.rw.name}"
+
+  policy = "${data.aws_iam_policy_document.rw.json}"
+}

--- a/terraform/terraform_override.tf
+++ b/terraform/terraform_override.tf
@@ -1,6 +1,6 @@
 terraform {
   backend "s3" {
-    region               = "us-west-2"
+    region               = "us-east-1"
     bucket               = "github-mgmt"
     key                  = "terraform.tfstate"
     workspace_key_prefix = "org"


### PR DESCRIPTION
Closes #23 

Terraform config which can be used to bootstrap AWS setup required by GitHub Management repos. I used it myself to prepare my PL provided account for use with github-mgmt repositories in testground, multiformats, etc.