### PR TITLE
Add file support

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -70,7 +70,7 @@ jobs:
           terraform_version: 1.1.4
           terraform_wrapper: false
       - name: Initialize terraform
-        run: terraform init
+        run: terraform init -upgrade
         working-directory: terraform
       - name: Select terraform workspace
         run: |

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -2,10 +2,17 @@ name: Upgrade
 
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        description: The github-mgmt-template ref to upgrade to
+        default: master
 
 jobs:
   upgrade:
     uses: protocol/github-mgmt-template/.github/workflows/upgrade_reusable.yml@master
+    with:
+      ref: inputs.ref
     secrets:
       GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
       GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', github.repository_owner)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}

--- a/.github/workflows/upgrade_reusable.yml
+++ b/.github/workflows/upgrade_reusable.yml
@@ -2,6 +2,12 @@ name: Upgrade (reusable)
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: true
+        description: The github-mgmt-template ref to upgrade to
+        default: master
     secrets:
       GITHUB_APP_ID:
         required: true
@@ -30,6 +36,7 @@ jobs:
         with:
           repository: protocol/github-mgmt-template
           path: github-mgmt-template
+          ref: ${{ github.event.inputs.ref }}
       - name: Checkout GitHub Management
         uses: actions/checkout@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - warning about GitHub Management repository access
 - PR template
 - examples to HOWTOs
+- repository_file support
 
 ### Changed
 - Upgrade (reusable) workflow: included docs and CHANGELOG in the upgrades
 - README: extracted sections to separate docs
 - GitHub Provider: upgraded to v4.23.0
+- Upgrade workflows: accept github-mgmt-template ref to upgrade to
 
 ### Fixed
 - links to supported resources in HOWTOs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade (reusable) workflow: included docs and CHANGELOG in the upgrades
 - README: extracted sections to separate docs
+- GitHub Provider: upgraded to v4.23.0

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -54,6 +54,8 @@ Running the `Sync` GitHub Action workflows refreshes the underlying terraform st
 
 ## Divergence from Terraform GitHub provider documentation
 
+`github_team.parent_team_id` accepts either an ID of a team or a name of a team.
+
 `github_repository_file.content` accepts either a content string or a path relative to `files` directory.
 
 `github_repository_file.branch` defaults to the default branch of the repository instead of `main`.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -50,6 +50,13 @@ Running the `Sync` GitHub Action workflows refreshes the underlying terraform st
 | [github_team](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team) | `team.json` | `team.name` | n/a | add/remove teams from your organization |
 | [github_team_repository](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_repository) | `team_repository.json` | `team.name`: `repository.name` | `github_team` | manage relationships between teams and repositories in your GitHub organization |
 | [github_team_membership](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_membership) | `team_membership.json` | `team.name`: `username` | `github_team` | add/remove users from teams in your organization |
+| [github_repository_file](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file) | `repository_file.json` | `repository.name`: `filename` | `github_repository` | add/remove files from repositories in your organization |
+
+## Divergence from Terraform GitHub provider documentation
+
+`github_repository_file.content` accepts either a content string or a path relative to `files` directory.
+
+`github_repository_file.branch` defaults to the default branch of the repository instead of `main`.
 
 # Limitations
 

--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -1,1 +1,0 @@
-# This should be a workflow which handles stale issues/PRs

--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -1,0 +1,1 @@
+# This should be a workflow which handles stale issues/PRs

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -111,6 +111,9 @@ while read resource; do
   resource_config="$(at_address "github_$resource.this" "$state" | jq 'map({"key": .index, "value": .values}) | from_entries')"
 
   case "$resource" in
+    "team")
+      resource_config="$(jq '. as $resource_config | map_values(.parent_team_id = (.parent_team_id as $parent_team_id | $resource_config | map(select(.id == $parent_team_id))[0].name // $parent_team_id))' <<< "$resource_config")"
+      ;;
     "repository_file")
       pushd "$root/files"
       path_by_content="$(find . -type f -exec jq -Rs '{ "\(@base64)": $file }' --arg file '{}' '{}' \; | jq -s 'add')"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -110,18 +110,27 @@ while read resource; do
   echo "Retrieving resources from state"
   resource_config="$(at_address "github_$resource.this" "$state" | jq 'map({"key": .index, "value": .values}) | from_entries')"
 
+  case "$resource" in
+    "repository_file")
+      pushd "$root/files"
+      path_by_content="$(find . -type f -exec jq -Rs '{ "\(@base64)": $file }' --arg file '{}' '{}' \; | jq -s 'add')"
+      popd
+      resource_config="$(jq 'map_values(.content = ($path_by_content["\(.content | @base64)"] // .content))' --argjson path_by_content "$path_by_content" <<< "$resource_config")"
+      ;;
+  esac
+
   echo "Ignoring ignored and required arguments"
   resource_config="$(jq "map_values(del($ignore_string))" <<< "$resource_config")"
 
-  if (( $(jq 'length' <<< "$required") > 1 )); then
-    echo "Breaking up top level keys"
+  for (( i=1; i<$(jq 'length' <<< "$required"); i++ )); do
+    echo "Breaking up top level keys #$i"
     resource_config="$(jq 'to_entries |
       map(.key |= split($separator)) |
-      map({"key": .key[0], "value": {"key": .key[1], "value": .value}}) |
+      map({"key": (.key[:-1] | join($separator)), "value": {"key": .key[-1], "value": .value}}) |
       group_by(.key) |
       map({"key": .[0].key, "value": map(.value) | from_entries}) |
       from_entries' --arg separator "$separator" <<< "$resource_config")"
-  fi
+  done
 
   echo "Saving new resource configuration"
   jq '.' <<< "$resource_config" > "$root/github/$organization/$resource.json"

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -27,3 +27,35 @@ data "github_repository" "this" {
 # @resources.team_repository.data
 # @resources.team_membership.data
 data "github_organization_teams" "this" {}
+
+data "github_branch" "this" {
+  for_each = merge([
+    for repository, config in data.github_repository.this :
+    {
+      for branch in config.branches :
+      "${repository}:${branch.name}" => {
+        repository = repository
+        branch     = branch.name
+      }
+    }
+  ]...)
+
+  branch     = each.value.branch
+  repository = each.value.repository
+}
+
+# @resources.repository_file.data
+data "github_tree" "this" {
+  for_each = {
+    for key, value in data.github_branch.this :
+    key => value if contains(keys(lookup(local.github, "repository_file", {})), value.repository) ?
+    contains([
+      for config in values(lookup(local.github, "repository_file", {})[value.repository]) :
+      lookup(config, "branch", data.github_repository.this[value.repository].default_branch)
+    ], value.branch) : false
+  }
+
+  recursive  = true
+  repository = each.value.repository
+  tree_sha   = data.github_branch.this["${each.value.repository}:${each.value.branch}"].sha
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -56,18 +56,20 @@ data "github_organization_teams" "this" {}
 data "github_branch" "this" {
   for_each = merge([
     for repository, files in lookup(local.github, "repository_file", {}) :
-    {
+    merge([
       for file, config in {
         for file, config in files :
         file => merge({
           branch = lookup(config, "branch", data.github_repository.this[repository].default_branch)
         }, config) if contains(keys(data.github_repository.this), repository)
       } :
-      "${repository}:${config.branch}" => {
-        repository = repository
-        branch     = config.branch
+      {
+        "${repository}:${config.branch}" = {
+          repository = repository
+          branch     = config.branch
+        }
       }
-    }
+    ]...)
   ]...)
 
   branch     = each.value.branch

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -28,6 +28,31 @@ data "github_repository" "this" {
 # @resources.team_membership.data
 data "github_organization_teams" "this" {}
 
+# once https://github.com/integrations/terraform-provider-github/issues/1131 is resolved
+# we can replace data.github_branch.this and data.github_tree.this with the following:
+# data "github_repository_file" "this" {
+#   for_each = merge([
+#     for repository, files in lookup(local.github, "repository_file", {}) :
+#     {
+#       for file, config in {
+#         for file, config in files :
+#         file => merge({
+#           branch = lookup(config, "branch", data.github_repository.this[repository].default_branch)
+#         }, config) if contains(keys(data.github_repository.this), repository)
+#       } :
+#       "${repository}/${file}:${config.branch}" => {
+#         repository = repository
+#         file       = file
+#         branch     = config.branch
+#       }
+#     }
+#   ]...)
+#
+#   repository = each.value.repository
+#   file       = each.value.file
+#   branch     = each.value.branch
+# }
+
 data "github_branch" "this" {
   for_each = merge([
     for repository, files in lookup(local.github, "repository_file", {}) :
@@ -55,5 +80,5 @@ data "github_tree" "this" {
 
   recursive  = true
   repository = each.value.repository
-  tree_sha   = data.value.sha
+  tree_sha   = each.value.sha
 }

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -219,7 +219,7 @@ resource "github_team" "this" {
   create_default_maintainer = try(each.value.create_default_maintainer, null)
   description               = try(each.value.description, null)
   ldap_dn                   = try(each.value.ldap_dn, null)
-  parent_team_id            = try(each.value.parent_team_id, null)
+  parent_team_id            = try(try(element(data.github_organization_teams.this, index(data.github_organization_teams.this.*.id, each.value.parent_team_id)), each.value.parent_team_id), null)
   privacy                   = try(each.value.privacy, null)
 
   lifecycle {

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -30,16 +30,17 @@ resource "github_repository" "this" {
   archived           = try(each.value.archived, null)
   auto_init          = try(each.value.auto_init, null)
   # default_branch         = try(each.value.default_branch, null)
-  delete_branch_on_merge = try(each.value.delete_branch_on_merge, null)
-  description            = try(each.value.description, null)
-  gitignore_template     = try(each.value.gitignore_template, null)
-  has_downloads          = try(each.value.has_downloads, null)
-  has_issues             = try(each.value.has_issues, null)
-  has_projects           = try(each.value.has_projects, null)
-  has_wiki               = try(each.value.has_wiki, null)
-  homepage_url           = try(each.value.homepage_url, null)
-  is_template            = try(each.value.is_template, null)
-  license_template       = try(each.value.license_template, null)
+  delete_branch_on_merge                  = try(each.value.delete_branch_on_merge, null)
+  description                             = try(each.value.description, null)
+  gitignore_template                      = try(each.value.gitignore_template, null)
+  has_downloads                           = try(each.value.has_downloads, null)
+  has_issues                              = try(each.value.has_issues, null)
+  has_projects                            = try(each.value.has_projects, null)
+  has_wiki                                = try(each.value.has_wiki, null)
+  homepage_url                            = try(each.value.homepage_url, null)
+  ignore_vulnerability_alerts_during_read = try(each.value.ignore_vulnerability_alerts_during_read, null)
+  is_template                             = try(each.value.is_template, null)
+  license_template                        = try(each.value.license_template, null)
   # private                = try(each.value.private, null)
   topics               = try(each.value.topics, null)
   visibility           = try(each.value.visibility, null)
@@ -92,6 +93,7 @@ resource "github_repository" "this" {
       html_url,
       http_clone_url,
       id,
+      ignore_vulnerability_alerts_during_read,
       is_template,
       license_template,
       node_id,

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,10 +1,8 @@
 terraform {
-  backend "s3" {}
-
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "4.19.2"
+      version = "4.23.0"
     }
   }
 


### PR DESCRIPTION
This PR adds support for file management via GitHub Management - via `repository_file` resource - see  https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_file.

We're going to use it to distribute stalebot workflows and/or CODEOWNERS files. 

Not merging yet because if https://github.com/integrations/terraform-provider-github/pull/1129 landed in `terraform-provider-github` then this could be made more efficient (as in syncing of managed files would require less API calls to GitHub - right now, sync operation when files are managed needs to retrieve the entire repository tree to check if a file still exists). 