### PR TITLE
chore: run sync once a week

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,6 +1,8 @@
 name: Sync
 
 on:
+  schedule:
+    - cron: 0 0 * * 0
   workflow_dispatch:
     inputs:
       workspaces:
@@ -85,7 +87,7 @@ jobs:
           git_branch='${{ github.ref_name }}-sync-${{ env.TF_WORKSPACE }}'
           git checkout -B "$git_branch"
           git add --all
-          git diff-index --quiet HEAD || git commit --message='sync ${{ env.TF_WORKSPACE }} (#${{ github.run_number }})'
+          git diff-index --quiet HEAD || git commit --message='chore: sync ${{ env.TF_WORKSPACE }} (#${{ github.run_number }})'
           git push origin "$git_branch" --force
   pull_request:
     needs: [prepare, sync]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - examples to HOWTOs
 - repository_file support
 - repository.default_branch support
+- weekly schedule to the synchronization workflow
 
 ### Changed
 - Synchronization script: to use GitHub API directly instead of relying on TF GH Provider's Data Sources


### PR DESCRIPTION
I think we should start running scheduled syncs in all of our github-mgmt repositories so that we stay up to date with GitHub configuration changes that were made through UI.