### PR TITLE
chore: pass inputs through env vars

### DIFF
--- a/.github/actions/git-config-user/action.yml
+++ b/.github/actions/git-config-user/action.yml
@@ -5,6 +5,6 @@ runs:
   using: composite
   steps:
     - run: |
-        git config --global user.email '${{ github.actor }}@users.noreply.github.com>'
-        git config --global user.name '${{ github.actor }}'
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com>"
+        git config --global user.name "${GITHUB_ACTOR}"
       shell: bash

--- a/.github/actions/git-push/action.yml
+++ b/.github/actions/git-push/action.yml
@@ -13,29 +13,31 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: |
-        protected="$(gh api 'repos/{owner}/{repo}/branches/${{ github.ref_name }}' --jq '.protected')"
+    - env:
+        SUFFIX: ${{ inputs.suffix }}
+      run: |
+        protected="$(gh api "repos/{owner}/{repo}/branches/${GITHUB_REF_NAME}" --jq '.protected')"
 
-        if [[ "$protected" == 'true' ]]; then
-          git_branch='${{ github.ref_name }}-${{ inputs.suffix }}'
+        if [[ "${protected}" == 'true' ]]; then
+          git_branch="${GITHUB_REF_NAME}-${SUFFIX}"
         else
-          git_branch='${{ github.ref_name }}'
+          git_branch="${GITHUB_REF_NAME}"
         fi
 
-        git checkout -B "$git_branch"
+        git checkout -B "${git_branch}"
 
-        if [[ "$protected" == 'true' ]]; then
-          git push origin "$git_branch" --force
+        if [[ "${protected}" == 'true' ]]; then
+          git push origin "${git_branch}" --force
           # fetching PR base because we want to compare against it and it might not have been checked out yet
-          git fetch origin ${{ github.ref_name }}
-          if [[ ! -z "$(git diff --name-only 'origin/${{ github.ref_name }}')" ]]; then
-            state="$(gh pr view "$git_branch" --json state --jq .state 2> /dev/null || echo '')"
-            if [[ "$state" != 'OPEN' ]]; then
-              gh pr create --body 'The changes in this PR were made by a bot. Please review carefully.' --head "$git_branch" --base '${{ github.ref_name }}' --fill
+          git fetch origin "${GITHUB_REF_NAME}"
+          if [[ ! -z "$(git diff --name-only "origin/${GITHUB_REF_NAME}")" ]]; then
+            state="$(gh pr view "${git_branch}" --json state --jq .state 2> /dev/null || echo '')"
+            if [[ "${state}" != 'OPEN' ]]; then
+              gh pr create --body 'The changes in this PR were made by a bot. Please review carefully.' --head "${git_branch}" --base "${GITHUB_REF_NAME}" --fill
             fi
           fi
         else
-          git push origin "$git_branch"
+          git push origin "${git_branch}"
         fi
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -39,16 +39,17 @@ jobs:
         id: sha
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULLS: ${{ steps.pull_request.outputs.issues-or-pull-requests }}
         run: |
-          if [[ '${{ github.event_name }}' == 'push' ]]; then
-            number="$(jq -r '.[0].number // ""' <<< '${{ steps.pull_request.outputs.issues-or-pull-requests }}')"
-            if [[ ! -z "$number" ]]; then
-              sha="$(gh pr view "$number" --json commits --jq '.commits[-1].oid')"
+          if [[ "${GITHUB_EVENT_NAME}" == 'push' ]]; then
+            number="$(jq -r '.[0].number // ""' <<< "${PULLS}")"
+            if [[ ! -z "${number}" ]]; then
+              sha="$(gh pr view "${number}" --json commits --jq '.commits[-1].oid')"
             fi
           else
-            sha='${{ github.sha }}'
+            sha="${GITHUB_SHA}"
           fi
-          echo "::set-output name=this::$sha"
+          echo "::set-output name=this::${sha}"
   apply:
     needs: [prepare]
     if: needs.prepare.outputs.sha != '' && needs.prepare.outputs.workspaces != ''
@@ -87,6 +88,7 @@ jobs:
       - name: Terraform Plan Download
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh run download -n ${{ env.TF_WORKSPACE }}_${{ needs.prepare.outputs.sha }}.tfplan --repo ${{ github.repository }}
+          SHA: ${{ needs.prepare.outputs.sha }}
+        run: gh run download -n "${TF_WORKSPACE }_${SHA}.tfplan" --repo "${GITHUB_REPOSITORY}"
       - name: Terraform Apply
-        run: terraform apply -lock-timeout=0s -no-color ${{ env.TF_WORKSPACE }}.tfplan
+        run: terraform apply -lock-timeout=0s -no-color "${TF_WORKSPACE}.tfplan"

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -33,13 +33,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Discover workspaces
         id: workspaces
+        env:
+          WORKSPACES: ${{ github.event.inputs.workspaces }}
         run: |
-          if [[ -z '${{ github.event.inputs.workspaces }}' ]]; then
+          if [[ -z "${WORKSPACES}" ]]; then
             workspaces="$(ls github | jq --raw-input '[.[0:-4]]' | jq -sc add)"
           else
-            workspaces="$(echo '${{ github.event.inputs.workspaces }}' | jq --raw-input 'split(" ")')"
+            workspaces="$(echo "${WORKSPACES}" | jq --raw-input 'split(" ")')"
           fi
-          echo "::set-output name=this::$workspaces"
+          echo "::set-output name=this::${workspaces}"
   clean:
     needs: [prepare]
     if: needs.prepare.outputs.workspaces != ''
@@ -55,6 +57,7 @@ jobs:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
       TF_LOCK: ${{ github.event.inputs.lock }}
+      TF_WORKSPACE_OPT: ${{ matrix.workspace }}
       AWS_ACCESS_KEY_ID: ${{ secrets.RW_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.RW_AWS_SECRET_ACCESS_KEY }}
       GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
@@ -77,14 +80,17 @@ jobs:
         working-directory: terraform
       - name: Select terraform workspace
         run: |
-          terraform workspace select '${{ matrix.workspace }}' || terraform workspace new '${{ matrix.workspace }}'
-          echo 'TF_WORKSPACE=${{ matrix.workspace }}' >> $GITHUB_ENV
+          terraform workspace select "${TF_WORKSPACE_OPT}" || terraform workspace new "${TF_WORKSPACE_OPT}"
+          echo "TF_WORKSPACE=${TF_WORKSPACE_OPT}" >> $GITHUB_ENV
         working-directory: terraform
       - name: Clean
+        env:
+          DRY_RUN: ${{ github.event.inputs.dry-run }}
+          REGEX: ^${{ github.event.inputs.regex }}$
         run: |
           dryRunFlag=''
-          if [[ '${{ github.event.inputs.dry-run }}' == 'true' ]]; then
+          if [[ "${DRY_RUN}" == 'true' ]]; then
             dryRunFlag='-dry-run'
           fi
-          terraform state list | grep -E '^${{ github.event.inputs.regex }}$' | sed 's/"/\\"/g' | xargs -I {} terraform state rm -lock=${{ env.TF_LOCK }} $dryRunFlag {}
+          terraform state list | grep -E "${REGEX}" | sed 's/"/\\"/g' | xargs -I {} terraform state rm -lock="${TF_LOCK}" "${dryRunFlag}" {}
         working-directory: terraform

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -26,12 +26,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - if: github.event_name == 'pull_request_target'
-        run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head
-          # we delete github directory first to ensure we only get YAMLs from the PR
-          rm -rf github && git checkout ${{ github.event.pull_request.head.sha }} -- github
         env:
+          NUMBER: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin "pull/${NUMBER}/head"
+          # we delete github directory first to ensure we only get YAMLs from the PR
+          rm -rf github && git checkout "${SHA}" -- github
       - name: Discover workspaces
         id: workspaces
         run: echo "::set-output name=this::$(ls github | jq --raw-input '[.[0:-4]]' | jq -sc add)"
@@ -73,7 +75,7 @@ jobs:
         run: terraform init
         working-directory: terraform
       - name: Plan terraform
-        run: terraform plan -refresh=false -lock=false -out=${{ env.TF_WORKSPACE }}.tfplan -no-color
+        run: terraform plan -refresh=false -lock=false -out="${TF_WORKSPACE}.tfplan" -no-color
         working-directory: terraform
       - name: Upload terraform plan
         uses: actions/upload-artifact@v2
@@ -97,11 +99,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - if: github.event_name == 'pull_request_target'
-        run: |
-          git fetch origin pull/${{ github.event.pull_request.number }}/head
-          rm -rf github && git checkout ${{ github.event.pull_request.head.sha }} -- github
         env:
+          NUMBER: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin "pull/${NUMBER}/head"
+          rm -rf github && git checkout "${SHA}" -- github
       - name: Setup terraform
         uses: hashicorp/setup-terraform@3d8debd658c92063839bc97da5c2427100420dec # v1.3.2
         with:
@@ -117,10 +121,10 @@ jobs:
       - name: Show terraform plans
         run: |
           for plan in $(find . -type f -name '*.tfplan'); do
-            echo "<details><summary>$(basename "$plan" '.tfplan')</summary>" >> TERRAFORM_PLANS.md
+            echo "<details><summary>$(basename "${plan}" '.tfplan')</summary>" >> TERRAFORM_PLANS.md
             echo '' >> TERRAFORM_PLANS.md
             echo '```' >> TERRAFORM_PLANS.md
-            echo "$(terraform show -no-color "$plan" 2>&1)" >> TERRAFORM_PLANS.md
+            echo "$(terraform show -no-color "${plan}" 2>&1)" >> TERRAFORM_PLANS.md
             echo '```' >> TERRAFORM_PLANS.md
             echo '' >> TERRAFORM_PLANS.md
             echo '</details>' >> TERRAFORM_PLANS.md
@@ -131,7 +135,7 @@ jobs:
         run: |
           echo 'COMMENT<<EOF' >> $GITHUB_ENV
           if [[ $(wc -c TERRAFORM_PLANS.md | cut -d' ' -f1) -ge 65000 ]]; then
-            echo 'Terraform plans are too long to post as a comment. Please inspect [Plan > Comment > Show terraform plans](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) instead.' >> $GITHUB_ENV
+            echo "Terraform plans are too long to post as a comment. Please inspect [Plan > Comment > Show terraform plans](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) instead." >> $GITHUB_ENV
           else
             cat TERRAFORM_PLANS.md >> $GITHUB_ENV
           fi

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -27,13 +27,15 @@ jobs:
         uses: actions/checkout@v2
       - name: Discover workspaces
         id: workspaces
+        env:
+          WORKSPACES: ${{ github.event.inputs.workspaces }}
         run: |
-          if [[ -z '${{ github.event.inputs.workspaces }}' ]]; then
+          if [[ -z "${WORKSPACES}" ]]; then
             workspaces="$(ls github | jq --raw-input '[.[0:-4]]' | jq -sc add)"
           else
-            workspaces="$(echo '${{ github.event.inputs.workspaces }}' | jq --raw-input 'split(" ")')"
+            workspaces="$(echo "${WORKSPACES}" | jq --raw-input 'split(" ")')"
           fi
-          echo "::set-output name=this::$workspaces"
+          echo "::set-output name=this::${workspaces}"
   sync:
     needs: [prepare]
     if: needs.prepare.outputs.workspaces != ''
@@ -49,6 +51,7 @@ jobs:
       TF_IN_AUTOMATION: 1
       TF_INPUT: 0
       TF_LOCK: ${{ github.event.inputs.lock }}
+      TF_WORKSPACE_OPT: ${{ matrix.workspace }}
       AWS_ACCESS_KEY_ID: ${{ secrets.RW_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.RW_AWS_SECRET_ACCESS_KEY }}
       GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
@@ -71,8 +74,8 @@ jobs:
         working-directory: terraform
       - name: Select terraform workspace
         run: |
-          terraform workspace select '${{ matrix.workspace }}' || terraform workspace new '${{ matrix.workspace }}'
-          echo 'TF_WORKSPACE=${{ matrix.workspace }}' >> $GITHUB_ENV
+          terraform workspace select "${TF_WORKSPACE_OPT}" || terraform workspace new "${TF_WORKSPACE_OPT}"
+          echo "TF_WORKSPACE=${TF_WORKSPACE_OPT}" >> $GITHUB_ENV
         working-directory: terraform
       - name: Sync
         run: |
@@ -84,11 +87,11 @@ jobs:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git_branch='${{ github.ref_name }}-sync-${{ env.TF_WORKSPACE }}'
-          git checkout -B "$git_branch"
+          git_branch="${GITHUB_REF_NAME}-sync-${TF_WORKSPACE }"
+          git checkout -B "${git_branch}"
           git add --all
-          git diff-index --quiet HEAD || git commit --message='chore: sync ${{ env.TF_WORKSPACE }} (#${{ github.run_number }})'
-          git push origin "$git_branch" --force
+          git diff-index --quiet HEAD || git commit --message="chore: sync ${TF_WORKSPACE} (#${GITHUB_RUN_NUMBER})'
+          git push origin "${git_branch}" --force
   pull_request:
     needs: [prepare, sync]
     if: needs.prepare.outputs.workspaces != ''
@@ -110,13 +113,15 @@ jobs:
         with:
           token: ${{ steps.token.outputs.token }}
       - uses: ./.github/actions/git-config-user
-      - run: |
+      - env:
+          WORKSPACES: ${{ needs.prepare.outputs.workspaces }}
+        run: |
           while read workspace; do
-            workspace_branch="${{ github.ref_name }}-sync-$workspace"
-            git fetch origin "$workspace_branch"
-            git merge --strategy-option=theirs "origin/$workspace_branch"
-            git push origin --delete "$workspace_branch"
-          done <<< "$(jq -r '.[]' <<< '${{ needs.prepare.outputs.workspaces }}')"
+            workspace_branch="${GITHUB_REF_NAME}-sync-${workspace}"
+            git fetch origin "${workspace_branch}"
+            git merge --strategy-option=theirs "origin/${workspace_branch}"
+            git push origin --delete "${workspace_branch}"
+          done <<< "$(jq -r '.[]' <<< "${WORKSPACES}")"
       - uses: ./.github/actions/git-push
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}

--- a/.github/workflows/upgrade_reusable.yml
+++ b/.github/workflows/upgrade_reusable.yml
@@ -45,14 +45,14 @@ jobs:
       - name: Copy files from the template
         run: |
           for file in $(git ls-files ':!:github/*.yml' ':!:scripts/__tests__/*' ':!:terraform/*_override.tf' ':!:.github/workflows/*_reusable.yml' ':!:README.md'); do
-            mkdir -p "../github-mgmt/$(dirname "$file")"
-            cp -f "$file" "../github-mgmt/$file"
+            mkdir -p "../github-mgmt/$(dirname "${file}")"
+            cp -f "${file}" "../github-mgmt/${file}"
           done
         working-directory: github-mgmt-template
       - uses: ./github-mgmt-template/.github/actions/git-config-user
       - run: |
           git add --all
-          git diff-index --quiet HEAD || git commit --message='upgrade (#${{ github.run_number }})'
+          git diff-index --quiet HEAD || git commit --message="upgrade (#${GITHUB_RUN_NUMBER})"
         working-directory: github-mgmt
       - uses: ./github-mgmt-template/.github/actions/git-push
         env:


### PR DESCRIPTION
We prefer usage of env vars (`${}`) instead of template replacements (`${{}}`) inside `run` steps. This PR formats workflow files according to this preference. 

It doesn't touch `update.yml` because it's being changed completely in https://github.com/protocol/github-mgmt-template/pull/64.