### PR TITLE
feat: add shared action for adding labels to all repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix workflow which executes user defined config transforms on PRs and after Apply
 - shared config fix rule which adds missing default branch protections
 - shared action for adding a file to all repositories
+- shared action for adding a label to all repositories
 
 ### Changed
 - Synchronization script: to use GitHub API directly instead of relying on TF GH Provider's Data Sources

--- a/scripts/src/actions/shared/add-file-to-all-repos.ts
+++ b/scripts/src/actions/shared/add-file-to-all-repos.ts
@@ -1,6 +1,7 @@
 import {Config} from '../../yaml/config'
 import {Repository} from '../../resources/repository'
 import {RepositoryFile} from '../../resources/repository-file'
+import * as core from '@actions/core'
 
 export async function addFileToAllRepos(
   name: string,
@@ -18,7 +19,7 @@ export async function addFileToAllRepos(
     const file = new RepositoryFile(repository.name, name)
     file.content = content
     if (!config.someResource(file)) {
-      console.log(`Adding ${file.file} file to ${file.repository} repository`)
+      core.info(`Adding ${file.file} file to ${file.repository} repository`)
       config.addResource(file)
     }
   }

--- a/scripts/src/actions/shared/add-label-to-all-repos.ts
+++ b/scripts/src/actions/shared/add-label-to-all-repos.ts
@@ -1,0 +1,41 @@
+import {Config} from '../../yaml/config'
+import {Repository} from '../../resources/repository'
+import {GitHub} from '../../github'
+import env from '../../env'
+import * as core from '@actions/core'
+
+export async function addLabelToAllRepos(
+  label: string,
+  color: string,
+  description: string,
+  repositoryFilter: (repository: Repository) => boolean = () => true
+): Promise<void> {
+  const config = Config.FromPath()
+  const github = await GitHub.getGitHub()
+
+  const repositories = config
+    .getResources(Repository)
+    .filter(r => !r.archived)
+    .filter(repositoryFilter)
+
+  for (const repository of repositories) {
+    // labels are not supported by GitHub Management yet
+    const labels = await github.client.paginate(
+      github.client.issues.listLabelsForRepo,
+      {
+        owner: env.GITHUB_ORG,
+        repo: repository.name
+      }
+    )
+    if (!labels.map(l => l.name).includes(label)) {
+      core.info(`Adding label ${label} to ${repository.name}`)
+      await github.client.issues.createLabel({
+        owner: env.GITHUB_ORG,
+        repo: repository.name,
+        name: label,
+        color: color,
+        description: description
+      })
+    }
+  }
+}


### PR DESCRIPTION
Adding labels cannot be performed via GitHub Management yet but we can have an action that can be executed locally. 