### PR TITLE
Make sync workflow push directly to the branch it runs on

### DIFF
--- a/.github/workflows/fix.yml
+++ b/.github/workflows/fix.yml
@@ -161,7 +161,7 @@ jobs:
       - if: steps.github-modified.outputs.this == 'true'
         run: |
           git add --all -- github
-          git commit -m "chore: fix [skip fix]"
+          git commit -m "fix@${GITHUB_RUN_ID} [skip fix]"
         working-directory: head
       - if: steps.github-modified.outputs.this == 'true' && github.event_name == 'pull_request_target'
         env:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -122,8 +122,4 @@ jobs:
             git merge --strategy-option=theirs "origin/${workspace_branch}"
             git push origin --delete "${workspace_branch}"
           done <<< "$(jq -r '.[]' <<< "${WORKSPACES}")"
-      - uses: ./.github/actions/git-push
-        env:
-          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-        with:
-          suffix: sync
+      - run: git push origin "${GITHUB_REF_NAME}" --force

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -116,6 +116,9 @@ jobs:
       - env:
           WORKSPACES: ${{ needs.prepare.outputs.workspaces }}
         run: |
+          echo "${GITHUB_RUN_ID}" > .sync
+          git add .sync
+          git commit --message="chore: sync@${GITHUB_RUN_ID}"
           while read workspace; do
             workspace_branch="${GITHUB_REF_NAME}-sync-${workspace}"
             git fetch origin "${workspace_branch}"

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -92,10 +92,10 @@ jobs:
           git add --all
           git diff-index --quiet HEAD || git commit --message="sync@${GITHUB_RUN_ID} ${TF_WORKSPACE}"
           git push origin "${git_branch}" --force
-  pull_request:
+  push:
     needs: [prepare, sync]
     if: needs.prepare.outputs.workspaces != ''
-    name: Pull request
+    name: Push
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -90,7 +90,7 @@ jobs:
           git_branch="${GITHUB_REF_NAME}-sync-${TF_WORKSPACE}"
           git checkout -B "${git_branch}"
           git add --all
-          git diff-index --quiet HEAD || git commit --message="chore: sync ${TF_WORKSPACE} (#${GITHUB_RUN_NUMBER})"
+          git diff-index --quiet HEAD || git commit --message="sync@${GITHUB_RUN_ID} ${TF_WORKSPACE}"
           git push origin "${git_branch}" --force
   pull_request:
     needs: [prepare, sync]
@@ -118,7 +118,7 @@ jobs:
         run: |
           echo "${GITHUB_RUN_ID}" > .sync
           git add .sync
-          git commit --message="chore: sync@${GITHUB_RUN_ID}"
+          git commit --message="sync@${GITHUB_RUN_ID}"
           while read workspace; do
             workspace_branch="${GITHUB_REF_NAME}-sync-${workspace}"
             git fetch origin "${workspace_branch}"

--- a/.github/workflows/upgrade_reusable.yml
+++ b/.github/workflows/upgrade_reusable.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: ./github-mgmt-template/.github/actions/git-config-user
       - run: |
           git add --all
-          git diff-index --quiet HEAD || git commit --message="upgrade (#${GITHUB_RUN_NUMBER})"
+          git diff-index --quiet HEAD || git commit --message="upgrade@${GITHUB_RUN_ID}"
         working-directory: github-mgmt
       - uses: ./github-mgmt-template/.github/actions/git-push
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plan: to wait for Apply workflow runs to finish
 - defaults: not to ignore any properties by default
 - add-file-to-all-repos: to accept a repo filter instead of an repo exclude list
+- sync: to push changes directly to the branch
 
 ### Fixed
 - links to supported resources in HOWTOs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,3 +45,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - parent_team_id retrieval from state
 - saving config sync result
 - how dry run flag is passed in the clean workflow
+- how sync invalidates PR plans

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - defaults: not to ignore any properties by default
 - add-file-to-all-repos: to accept a repo filter instead of an repo exclude list
 - sync: to push changes directly to the branch
+- automated commit messages: to include github run id information
 
 ### Fixed
 - links to supported resources in HOWTOs

--- a/docs/HOWTOS.md
+++ b/docs/HOWTOS.md
@@ -93,10 +93,9 @@ I push my changes to a new branch and create a PR. An admin reviews the PR and m
 
 *NOTE*: Remember that the `Sync` operation modifes terraform state. Even if you run it from a branch, it modifies the global state that is shared with other branches. There is only one terraform state per organization.
 
-*NOTE*: If you run the `Sync` from an unprotected branch, then the workflow will commit changes to it directly.
+*NOTE*: `Sync` will force push changes directly to the branch you run it from.
 
 - Run `Sync` GitHub Action workflow from your desired `branch` - *this will import all the resources from the actual GitHub configuration state into GitHub Management*
-- Merge the pull request that the workflow created once the `Comment` check passes and you verify the plan posted as a comment - *the plan should not contain any changes*
 
 ### ...upgrade GitHub Management?
 


### PR DESCRIPTION
Fixes #71 by implementing a direct force push in sync workflow.
Fixes #70 by always creating a `.sync` file during sync workflow run.

###### Testing
- [x] `pl-strflt` org - https://github.com/pl-strflt/github-mgmt/actions/runs/3098310394