### PR TITLE
Fix repository files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - how dry run flag is passed in the clean workflow
 - how sync invalidates PR plans
 - support for pull_request_bypassers in branch protection rules
+- how repository files are imported

--- a/scripts/__tests__/sync.test.ts
+++ b/scripts/__tests__/sync.test.ts
@@ -1,14 +1,79 @@
 import 'reflect-metadata'
 
-import {Config as YAMLConfig} from '../src/yaml/config'
-import {State as TFConfig} from '../src/terraform/state'
+import * as YAML from 'yaml'
+
+import * as config from '../src/yaml/config'
+import * as state from '../src/terraform/state'
 import {sync} from '../src/sync'
+import {GitHub} from '../src/github'
+import env from '../src/env'
+import {Resource} from '../src/resources/resource'
+import {RepositoryFile} from '../src/resources/repository-file'
 
 test('sync', async () => {
-  const yamlConfig = new YAMLConfig('{}')
-  const tfConfig = await TFConfig.New()
+  const yamlConfig = new config.Config('{}')
+  const tfConfig = await state.State.New()
 
-  const expectedYamlConfig = YAMLConfig.FromPath()
+  const expectedYamlConfig = config.Config.FromPath()
+
+  await sync(tfConfig, yamlConfig)
+
+  yamlConfig.format()
+
+  expect(yamlConfig.toString()).toEqual(expectedYamlConfig.toString())
+})
+
+test('sync new repository file', async () => {
+  const yamlSource = {
+    repositories: {
+      blog: {
+        files: {
+          'README.md': {
+            content: 'Hello, world!'
+          }
+        }
+      }
+    }
+  }
+  const tfSource = {
+    values: {
+      root_module: {
+        resources: [] as any[] // eslint-disable-line @typescript-eslint/no-explicit-any
+      }
+    }
+  }
+
+  const loadStateMock = jest.spyOn(state, 'loadState')
+  const getRepositoryFileMock = jest.spyOn(GitHub.github, 'getRepositoryFile')
+
+  loadStateMock.mockImplementation(async () => JSON.stringify(tfSource))
+  getRepositoryFileMock.mockImplementation(
+    async (repository: string, path: string) => ({
+      path,
+      url: `https://github.com/${env.GITHUB_ORG}/${repository}/blob/main/${path}`
+    })
+  )
+
+  const yamlConfig = new config.Config(YAML.stringify(yamlSource))
+  const tfConfig = await state.State.New()
+
+  const addResourceMock = jest.spyOn(tfConfig, 'addResource')
+
+  addResourceMock.mockImplementation(
+    async (_id: string, resource: Resource) => {
+      tfSource.values.root_module.resources.push({
+        mode: 'managed',
+        type: RepositoryFile.StateType,
+        values: {
+          repository: (resource as RepositoryFile).repository,
+          file: (resource as RepositoryFile).file,
+          ...resource
+        }
+      })
+    }
+  )
+
+  const expectedYamlConfig = new config.Config(YAML.stringify(yamlSource))
 
   await sync(tfConfig, yamlConfig)
 

--- a/scripts/__tests__/sync.test.ts
+++ b/scripts/__tests__/sync.test.ts
@@ -50,7 +50,8 @@ test('sync new repository file', async () => {
   getRepositoryFileMock.mockImplementation(
     async (repository: string, path: string) => ({
       path,
-      url: `https://github.com/${env.GITHUB_ORG}/${repository}/blob/main/${path}`
+      url: `https://github.com/${env.GITHUB_ORG}/${repository}/blob/main/${path}`,
+      ref: 'main'
     })
   )
 

--- a/scripts/src/github.ts
+++ b/scripts/src/github.ts
@@ -224,13 +224,18 @@ export class GitHub {
         })
       ).data
       if (repo.owner.login === env.GITHUB_ORG && repo.name === repository) {
-        return (
+        const file = (
           await this.client.repos.getContent({
             owner: env.GITHUB_ORG,
             repo: repository,
-            path
+            path,
+            ref: repo.default_branch
           })
         ).data as {path: string; url: string}
+        return {
+          ...file,
+          ref: repo.default_branch
+        }
       } else {
         core.debug(
           `${env.GITHUB_ORG}/${repository} has moved to ${repo.owner.login}/${repo.name}`

--- a/scripts/src/resources/repository-branch-protection-rule.ts
+++ b/scripts/src/resources/repository-branch-protection-rule.ts
@@ -1,10 +1,4 @@
-import {
-  Exclude,
-  Expose,
-  instanceToPlain,
-  plainToClassFromExist,
-  Type
-} from 'class-transformer'
+import {Exclude, Expose, plainToClassFromExist, Type} from 'class-transformer'
 import {GitHub} from '../github'
 import {Id, StateSchema} from '../terraform/schema'
 import {Path, ConfigSchema} from '../yaml/schema'

--- a/scripts/src/resources/repository-file.ts
+++ b/scripts/src/resources/repository-file.ts
@@ -118,6 +118,6 @@ export class RepositoryFile implements Resource {
   }
 
   getStateAddress(): string {
-    return `${RepositoryFile.StateType}.this["${this.repository}:${this.file}"]`
+    return `${RepositoryFile.StateType}.this["${this.repository}/${this.file}"]`
   }
 }

--- a/scripts/src/resources/repository-file.ts
+++ b/scripts/src/resources/repository-file.ts
@@ -39,11 +39,12 @@ export class RepositoryFile implements Resource {
     const github = await GitHub.getGitHub()
     const result: [Id, RepositoryFile][] = []
     for (const file of files) {
-      if (
-        (await github.getRepositoryFile(file.repository, file.file)) !==
-        undefined
-      ) {
-        result.push([`${file.repository}/${file.file}`, file])
+      const remoteFile = await github.getRepositoryFile(
+        file.repository,
+        file.file
+      )
+      if (remoteFile !== undefined) {
+        result.push([`${file.repository}/${file.file}:${remoteFile.ref}`, file])
       }
     }
     return result

--- a/scripts/src/sync.ts
+++ b/scripts/src/sync.ts
@@ -4,11 +4,9 @@ import {Id} from './terraform/schema'
 import {Config} from './yaml/config'
 
 export async function sync(state: State, config: Config): Promise<void> {
-  await state.refresh()
-
   const resources: [Id, Resource][] = []
   for (const resourceClass of ResourceConstructors) {
-    const oldResources = state.getResources(resourceClass)
+    const oldResources = config.getResources(resourceClass)
     const newResources = await resourceClass.FromGitHub(oldResources)
     resources.push(...newResources)
   }

--- a/scripts/src/terraform/state.ts
+++ b/scripts/src/terraform/state.ts
@@ -9,8 +9,9 @@ import * as cli from '@actions/exec'
 import * as fs from 'fs'
 import * as core from '@actions/core'
 import * as HCL from 'hcl2-parser'
+import * as thisModule from './state'
 
-async function loadState() {
+export async function loadState() {
   let source = ''
   if (env.TF_EXEC === 'true') {
     core.info('Loading state from Terraform state file')
@@ -33,7 +34,7 @@ async function loadState() {
 
 export class State {
   static async New() {
-    return new State(await loadState())
+    return new State(await thisModule.loadState())
   }
 
   private _ignoredProperties: Record<string, string[]> = {}
@@ -106,7 +107,7 @@ export class State {
         cwd: env.TF_WORKING_DIR
       })
     }
-    this.setState(await loadState())
+    this.setState(await thisModule.loadState())
   }
 
   getAllResources(): Resource[] {


### PR DESCRIPTION
As it turns out, we were importing repository files on sync incorrectly because:
- the terraform state path provided to the import had `:` instead of `/` (now both use `/`)
- the import operated on `main` whereas plan uses default branch (now both use default branch)