### PR TITLE
feat: find sha for plan using proper credentials

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -27,34 +27,16 @@ jobs:
       - name: Discover workspaces
         id: workspaces
         run: echo "this=$(ls github | jq --raw-input '[.[0:-4]]' | jq -sc add)" >> $GITHUB_OUTPUT
+      - run: npm ci && npm run build
+        working-directory: scripts
       - name: Find sha for plan
         id: sha
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          QUERY: repository:${{ github.repository }} ${{ github.sha }}
-        uses: actions/github-script@v6
-        with:
-          result-encoding: string
-          script: |
-            if (process.env.GITHUB_EVENT_NAME === 'push') {
-              const { data: search } = await github.rest.search.issuesAndPullRequests({
-                q: process.env.QUERY,
-                per_page: 1
-              });
-              if (search.total_count !== 0) {
-                const { data: pulls } = await github.rest.pulls.listCommits({
-                  owner: process.env.GITHUB_REPOSITORY_OWNER,
-                  repo: process.env.GITHUB_REPOSITORY.slice(process.env.GITHUB_REPOSITORY_OWNER.length + 1),
-                  pull_number: search.items[0].number,
-                  per_page: 100
-                });
-                return pulls.at(-1).sha;
-              } else {
-                return '';
-              }
-            } else {
-              return process.env.GITHUB_SHA;
-            }
+          GITHUB_APP_ID: ${{ secrets.RW_GITHUB_APP_ID }}
+          GITHUB_APP_INSTALLATION_ID: ${{ secrets[format('RW_GITHUB_APP_INSTALLATION_ID_{0}', matrix.workspace)] || secrets.RW_GITHUB_APP_INSTALLATION_ID }}
+          GITHUB_APP_PEM_FILE: ${{ secrets.RW_GITHUB_APP_PEM_FILE }}
+        run: node lib/actions/find-sha-for-plan.js
+        working-directory: scripts
   apply:
     needs: [prepare]
     if: needs.prepare.outputs.sha != '' && needs.prepare.outputs.workspaces != ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - workflows: not to use deprecated GitHub Actions runners anymore
 - workflows: not to use deprecated GitHub Actions expressions anymore
 - tf: to prevent destroy of membership and repository resources
+- apply: find sha for plan using proper credentials
 
 ### Fixed
 - links to supported resources in HOWTOs

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7571,9 +7571,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "engines": {
         "node": ">= 14"
       }
@@ -13349,9 +13349,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/scripts/src/actions/find-sha-for-plan.ts
+++ b/scripts/src/actions/find-sha-for-plan.ts
@@ -1,0 +1,35 @@
+import {GitHub} from '../github'
+import {context} from '@actions/github'
+import core from '@actions/core'
+
+async function findShaForPlan() {
+  const github = await GitHub.getGitHub()
+
+  if (context.eventName !== 'push') {
+    return context.sha
+  }
+
+  const pulls = await github.client.paginate(github.client.search.issuesAndPullRequests, {
+    q: `repository:${context.repo.owner}/${context.repo.repo} ${context.sha} type:pr is:merged`
+  })
+
+  if (pulls.length === 0) {
+    return ''
+  }
+
+  const pull = pulls[0]
+  const commits = await github.client.paginate(github.client.pulls.listCommits, {
+    ...context.repo,
+    pull_number: pull.number,
+  })
+
+  if (commits.length === 0) {
+    return ''
+  }
+
+  return commits[commits.length - 1].sha
+}
+
+findShaForPlan().then(sha => {
+  core.setOutput('result', sha)
+})


### PR DESCRIPTION
This PR changes how we find the plan to apply after a merge. Previously, we were using the default GHA token for that but recently we've been seeing more and more rate limits hits. I also moved the script to TS to make it easier to follow. 